### PR TITLE
Motor block rules change

### DIFF
--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -10,7 +10,7 @@ temporary paralysis (motor block) which if gone unnoticed for too long can have 
 It is therefore important for clinical staff to have an overview of who on the units is using an epidural for pain relief and what their 
 level of motor block (temporary paralysis) in order to ensure patient safety. 
 
-All patients who have been on an epidural in (the last twelve hours) need to have an assessment of their level of motor block to their right and left leg 2 hourly in the day (08:00-19:59) and 4 hourly in the night (20:00-07:59).
+All patients who have been on an epidural in (the last twelve hours) need to have an assessment of their level of motor block to their right and left leg 2 hourly in the day (08:00-19:59) and 4 hourly in the night (20:00-07:59) until there is no more motor block (both scores are zero).
 
 The motor block assessment metric will have its own tile, floor plan and individual chart. An icon indicating which patients are on an epidural will also be included on the pain floor plan. 
 
@@ -191,4 +191,36 @@ These are weekly percentage (p-charts) SPC charts
 Calendar day defined as 00:00 - 23:59
 
 Week defined a Monday 00:00 – Sunday 23:59
+
+
+## Chart 1a - DAY Motor Block Assessment Time Interval Chart
+
+Day start time is 08:15 and end time is 20:14 to allow for 15 minutes documentation leeway. 
+
+
+1.  Look at motor block assessment measurement intervals between the hours of 08:15 and 20:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
+2.   Numerator = count of time intervals that are ≤ 2:00 hours for the DAY category
+- *note SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guideline)*
+  3. Denominator (adjusted) = count all assessment measurement intervals between the hours of  08:15 and 20:14 in that week that are > 2:00 hours and ADD +1 to denominator for each one hour period greater than the permitted 1:00 hour.
+
+For example: (i) an 2.01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional 1:00hr over the permitted one hour for this category; (ii) 3.01 hr measurement interval will count as 3 in the adjusted denominator: (iii) 4.01hr measurement interval will count as 4 in the adjusted denominator etc.....
+4. Generate percentage of measurement intervals for that week that are 1 hour or less: numerator / denominator (adjusted)
+5. Plot on weekly chart
+
+## Chart 2b- NIGHT RASS Assessment Time Interval Chart
+
+
+Night start time is 20:15 and end time is 08:14 to allow for 15 minutes documentation leeway.  
+
+
+1. Look at motor block assessment measurement intervals between the hours of 20:15 and 08:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
+2. Numerator = count of time intervals that are ≤ 4:00 hours for the NIGHT category
+- *SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guidance)*
+3. Denominator (adjusted) = count all assessment measurement intervals between the hours of 22:00 and 05.59 in that week that are >8:00 hours and ADD +1 to denominator for each four hour period greater than the permitted 4:00 hours
+
+For example: (i) an 8:01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional 4:00hr over the permitted four hours for this category; (ii) 12:01hr measurement interval will count as 3 in the adjusted denominator; (iii) 16:01hr measurement interval will count as 4 in the adjusted denominator etc...
+4. Generate percentage of measurement intervals for that week that are 4:00 hours or less: numerator / denominator (adjusted)
+5. Plot on weekly chart
+
+ 
 

--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -79,7 +79,7 @@ Once both scores have resumed to zero, motor block assessment is no longer requi
 
 Worked example:
 
-A patient has the following assessments calculated:
+A patient has the following assessments documented:
 
 1) 09:00 Motor block r leg = 2, Motor block l leg = 1
 2) 11:00 Motor block r leg =1, Motor block l leg = 1
@@ -122,7 +122,7 @@ calculate respective DAY and NIGHT mean motor block assessment measurement inter
 
 ## MOTOR BLOCK ASSESSMENT - EPIDURAL PATIENTS FLOOR PLAN
 
-All patients who have been on an epidural in the last 12 hours need to have their level of motor block (level of paralysis) assessed 2 hourly in the day and 4 hourly in the day. 
+All patients who have been on an epidural in the last 12 hours need to have their level of motor block (level of paralysis) assessed 2 hourly in the day and 4 hourly in the day until both right and left leg scores are 0. 
 
 
 ELIGIBILITY
@@ -143,19 +143,21 @@ All patients with an epidural volume infused in the last 12 hours.
 
 
 ## Secondary Label Assessment of Motor Block 
-*In addition to the last documented Motor Block Assessment, we need to display whether a motor block assessment is overdue (missingness). If a Motor Block Assessment is overdue, we need know what the last reading was as well. 
 
-1. If there has never been an 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' since the patients has been classified as 'on epidural', then label patient as 'missing assessment'. Red Hashed and no fill bed.  
-2. If the current time is 08:00-19:59, if either 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' have not been completed in the last two hours, then label patient as 'missing' and forward fill the latest motor block assessment reading (red amber green). Bed to be red hashed outline (with fill of colour from forward filled entry). 
-3. If the current time is 20:00-07:59, if either 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' have not been completed in the last four hours, then label patient as 'missing' and forward fill the latest motor block assessment reading (red amber green). 
-Bed to be red hashed outline  (with fill of colour from forward filled entry).
+*In addition to the last documented Motor Block Assessment, we need to display whether a motor block assessment is overdue (missingness). If a Motor Block Assessment is overdue, we need need to display both the last motor block assessment reading and that the score is overdue.* 
+
+1. If there has never been an 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' since the patient has been classified as 'on epidural', then label patient as 'missing assessment'. Red Hashed and no fill bed.  
+2. If the current time is 08:00-19:59, and if either the latest documented motor block score (r or l leg) was >0, and 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' have not been completed in the last two hours, then label patient as 'missing' and forward fill the latest motor block assessment reading (red amber green). Bed to be red hashed outline (with fill of colour from forward filled entry).
+4. If the current time is 20:00-07:59, and if either the latest documented motor block score (r or l leg) was >0, and if either 'Assessment of Motor Block Lt leg' or 'Assessment of Motor Block Rt leg assessment' have not been completed in the last four hours, then label patient as 'missing' and forward fill the latest motor block assessment reading (red amber green).
+5. During both day and night shifts, if both of the latest documented motor block r and l leg scores were zero, then do not label patient as missing even if there are no more scores. Forward fill the latest motor block assessment green reading until the end of the 12 hour period. 
+
 _______________________________________________
 
 ## [F] Classification Rules: Individual patient chart
 
 - X-axis time in hours, range 0-72 hours, default to 24 hours
 - Y-axis left is motor block assessment score (0 to 3) with 0 denoting no paralysis and 3 denoting full paralysis of either leg.
-- Use rules on lines 110-115 to determine classification for individual charts
+- Use labeling rules above to determine classification for individual charts
 
    
 
@@ -180,12 +182,11 @@ g. X on x axis to denote patient not on epidural in the last 12 hours.
 
 ## [D] SPC CHARTS
 
-Operational definition - For patients on epidurals, what percentage of motor block assessments are done on time as per guidelines. Chart a- day, Char b- night. 
+Operational definition - For patients on epidurals, what percentage of motor block assessments are done on time as per guidelines?
 
-Measurement Interval (for motor block assessment scoring only)
-Average time between motorblock assessments - note suggest not on front tile- TBC. 
+There are two SPC charts (A) Day and (B) Night
 
-ABC SPC CHARTS (refer to XYZ metric in classification
+
 
 Calendar day defined as 00:00 - 23:59
 Week defined as Monday 00:00 – Sunday 23:59

--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -198,10 +198,10 @@ Week defined a Monday 00:00 – Sunday 23:59
 Day start time is 08:15 and end time is 20:14 to allow for 15 minutes documentation leeway. 
 
 
-1.  Look at motor block assessment measurement intervals between the hours of 08:15 and 20:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
+1.  Look at motor block assessment measurement intervals (for which the first of the pair in the measurement interval is between the hours of 08:15 and 20:14) each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
 2.   Numerator = count of time intervals that are ≤ 2:00 hours for the DAY category
 - *note SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guideline)*
-  3. Denominator (adjusted) = count all motor block assessment measurement intervals (for which the first measurement in the pair is between the hours of 08:15 and 20:14) in that week that are > 4:00 hours and ADD +1 to denominator for each measurement interval missed.
+  3. Denominator (adjusted) = count all motor block assessment measurement intervals in that week that are > 4:00 hours and ADD +1 to denominator for each measurement interval missed.
 
 For example: (i) an 4.01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional having missed the next expected measurement; (ii) 6.01 hr measurement interval will count as 3 in the adjusted denominator: (iii) 8.01hr measurement interval will count as 4 in the adjusted denominator etc.....
 4. Generate percentage of DAY SHIFT measurement intervals for that week that are 2 hour or less: numerator / denominator (adjusted)
@@ -212,10 +212,10 @@ For example: (i) an 4.01hr measurement interval will count as 2 in the adjusted 
 Night start time is 20:15 and end time is 08:14 to allow for 15 minutes documentation leeway.  
 
 
-1. Look at motor block assessment measurement intervals between the hours of 20:15 and 08:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
+1. Look at motor block assessment measurement intervals (for which the first of the pair in the measurement interval is between the hours of 20:15 and 08:14 each day). Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
 2. Numerator = count of time intervals that are ≤ 4:00 hours for the NIGHT category
 - *SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guidance)*
-3. Denominator (adjusted) = count all assessment measurement intervals (for which the first measurement in the pair occurs between the hours of 20:15 and 08:14) in that week that are >8:00 hours and ADD +1 to denominator for each measurement interval missed.
+3. Denominator (adjusted) = count all assessment measurement intervals  in that week that are >8:00 hours and ADD +1 to denominator for each measurement interval missed.
 
 For example: (i) an 8:01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for having missed the next expected measurement; (ii) 12:01hr measurement interval will count as 3 in the adjusted denominator
 4. Generate percentage of measurement intervals for that week that are 4:00 hours or less: numerator / denominator (adjusted)

--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -193,7 +193,7 @@ Calendar day defined as 00:00 - 23:59
 Week defined a Monday 00:00 – Sunday 23:59
 
 
-## Chart 1a - DAY Motor Block Assessment Time Interval Chart
+## Chart 1a - DAY Motor Block Assessment Interval Chart
 
 Day start time is 08:15 and end time is 20:14 to allow for 15 minutes documentation leeway. 
 
@@ -201,14 +201,13 @@ Day start time is 08:15 and end time is 20:14 to allow for 15 minutes documentat
 1.  Look at motor block assessment measurement intervals between the hours of 08:15 and 20:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
 2.   Numerator = count of time intervals that are ≤ 2:00 hours for the DAY category
 - *note SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guideline)*
-  3. Denominator (adjusted) = count all assessment measurement intervals between the hours of  08:15 and 20:14 in that week that are > 2:00 hours and ADD +1 to denominator for each one hour period greater than the permitted 1:00 hour.
+  3. Denominator (adjusted) = count all motor block assessment measurement intervals (for which the first measurement in the pair is between the hours of 08:15 and 20:14) in that week that are > 4:00 hours and ADD +1 to denominator for each measurement interval missed.
 
-For example: (i) an 2.01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional 1:00hr over the permitted one hour for this category; (ii) 3.01 hr measurement interval will count as 3 in the adjusted denominator: (iii) 4.01hr measurement interval will count as 4 in the adjusted denominator etc.....
-4. Generate percentage of measurement intervals for that week that are 1 hour or less: numerator / denominator (adjusted)
+For example: (i) an 4.01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional having missed the next expected measurement; (ii) 6.01 hr measurement interval will count as 3 in the adjusted denominator: (iii) 8.01hr measurement interval will count as 4 in the adjusted denominator etc.....
+4. Generate percentage of DAY SHIFT measurement intervals for that week that are 2 hour or less: numerator / denominator (adjusted)
 5. Plot on weekly chart
 
-## Chart 2b- NIGHT RASS Assessment Time Interval Chart
-
+## Chart 1b- NIGHT Motor Block Assessment Interval Chart
 
 Night start time is 20:15 and end time is 08:14 to allow for 15 minutes documentation leeway.  
 
@@ -216,9 +215,9 @@ Night start time is 20:15 and end time is 08:14 to allow for 15 minutes document
 1. Look at motor block assessment measurement intervals between the hours of 20:15 and 08:14 each day. Reference measurement interval rules for tile calculation above making sure to not include any intervals after both scores have resumed to zero. 
 2. Numerator = count of time intervals that are ≤ 4:00 hours for the NIGHT category
 - *SPC denominator adjustment required for excessively long measurement intervals (those that are 2x accepted measurement interval from clinical guidance)*
-3. Denominator (adjusted) = count all assessment measurement intervals between the hours of 22:00 and 05.59 in that week that are >8:00 hours and ADD +1 to denominator for each four hour period greater than the permitted 4:00 hours
+3. Denominator (adjusted) = count all assessment measurement intervals (for which the first measurement in the pair occurs between the hours of 20:15 and 08:14) in that week that are >8:00 hours and ADD +1 to denominator for each measurement interval missed.
 
-For example: (i) an 8:01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for being an additional 4:00hr over the permitted four hours for this category; (ii) 12:01hr measurement interval will count as 3 in the adjusted denominator; (iii) 16:01hr measurement interval will count as 4 in the adjusted denominator etc...
+For example: (i) an 8:01hr measurement interval will count as 2 in the adjusted denominator - once for the measurement and once for having missed the next expected measurement; (ii) 12:01hr measurement interval will count as 3 in the adjusted denominator
 4. Generate percentage of measurement intervals for that week that are 4:00 hours or less: numerator / denominator (adjusted)
 5. Plot on weekly chart
 

--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -186,11 +186,9 @@ Operational definition - For patients on epidurals, what percentage of motor blo
 
 There are two SPC charts (A) Day and (B) Night
 
-
+These are weekly percentage (p-charts) SPC charts
 
 Calendar day defined as 00:00 - 23:59
-Week defined as Monday 00:00 – Sunday 23:59
 
-
-These are weekly percentage (p-charts) SPC
 Week defined a Monday 00:00 – Sunday 23:59
+

--- a/informus/rules/Epidural and motor block.md
+++ b/informus/rules/Epidural and motor block.md
@@ -18,6 +18,7 @@ The motor block assessment metric will have its own tile, floor plan and individ
 There will be two SPC charts of the Percentage of Motor Block Assessments done on time as per guidelines (A- Day and B- Night). 
 
 EPIC Flowsheets
+
 Flowsheet	Row ID | Manual/Automatic/Calculated Input | Comments	| Expected documentation frequency
 
 # Motor Block Assessment
@@ -40,15 +41,15 @@ Flowsheet	Row ID | Manual/Automatic/Calculated Input | Comments	| Expected docum
 
 
 ## ELIGIBILITY
-All patients who have received local anaesthesia via an epidural catheter in the last 12 hours. If a patient has a number equal to or greater than zero entered in flowsheet  Epidural drugs | Volume (mL) | 7001026  within the last ?12 hours (use 12 hours for now, but this may be amended), they are eligible. 
+All patients who have received local anaesthesia via an epidural catheter in the last 12 hours. If a patient has a number equal to or greater than zero entered in flowsheet  Epidural drugs | Volume (mL) | 7001026  within the last 12 hours, they are eligible. 
 
 *Note these patients will more frequently be found on the post-surgical units, T06 and PACU*
 
 ## VALIDITY
 
-A patient is classified as 'on an epidural' for ?12 hours following data entry in the flowsheet. 
+A patient is classified as 'on an epidural' for 12 hours following data entry in the flowsheet 7001026. 
 
-If a patient is 'on epidural' they are required to have a motor block assessment documented for at least ?12 hours following any data entered into flowsheet 7001026.: 2 hourly during the day shift (08:00-19:59), and 4 hourly during the night shift (20:00-07:59) ?unless red flag or worsening bromage score.... Define! 
+If a patient is 'on epidural' they are required to have a motor block assessment documented for at least 18 hours following any data entered into flowsheet 7001026 or until both the right and left motor block assessment scores are '0'. The required frequency of documentation is 2 hourly during the day shift (08:00-19:59), and 4 hourly during the night shift (20:00-07:59). 
 
 30415249 Motor block assessment left leg
 30415250 Motor block assessment right leg
@@ -60,7 +61,7 @@ If a patient is 'on epidural' they are required to have a motor block assessment
 
 ### Number of patients on epidural
 
-The epidural data on the front tile is a real time view of (a) the number of patients who are on an epidural (using above eligiblity criteria of volume infused within the last 12 hours) shown as a number (at each refresh looks back and collect all the current epidural flowsheets), (b) the average time between motor block assessments. 
+The epidural data on the front tile is a real time view of (a) the number of patients who are on an epidural (using above eligibility criteria of volume infused within the last 12 hours) shown as a number (at each refresh looks back and collect all the current epidural flowsheets), (b) the average time between motor block assessments. 
 
 Calculate the number of patients who are currently on the unit and have had a number equal to or greater than zero in epidural volume flowsheet 7001026 documented in the last 12 hours. Discharged patients are not included.
 
@@ -70,24 +71,49 @@ Present this number on the front tile as 'number of patients on epidural'.
 
 Measurement Interval - average time between motor block assessments - front tile metric calculation
 
-this calculation will look at all Motor block assessments (including those that are not on sedation or mechanically ventilated)
-average time between scores should be calculated from ACTUAL documented RASS scores in EPIC (ie. those with a _dt stamp) and not any forward filled scores
-there needs to be a minimum of two scores to calculate a measurement interval (if a patient has only just been admitted with one RASS score documented, or if a patient only has one RASS score during their entire ICU admission, calculation will not be possible and data will not be included on front tile metric
-the data on the front tile looks back from the current time to 24 hours in the past
-there will be two measurement interval calculations displayed on the front tile: DAY (08:00-19:59) and NIGHT (20:00-07:59)
-in line with other metrics we should provide some leeway (15 minutes) in charting documentation, therefore (adjusted time frame): DAY (08:00-19:59) and NIGHT (20:00-07:59)
-the leeway is to mitigate skewed mean interval, particularly in the DAY calculation (e.g. 08:01 motor block assessment, time interval calculated with a NIGHT RASS at 02:00, would give a 04:01 measurement interval which would skew daytime data, the 15 minute leeway may need to be reviewed if insufficient
-the _dt of each measurement determines whether it is categorised as 'DAY' or 'NIGHT', but in order to complete the measurement interval calculation, a preceding measurement can be in the opposing category
-worked example:
+This calculation will look at all Motor block assessment intervals for epidural patients. 
+
+There needs to be a minimum of two scores of >0 at two different dt_stamps to calculate a measurement interval. Note that assessing the motor block involves documenting both right and left leg scores simultaneously. Simultaneous right and leg measurements should not be used in the measurement interval calculation (if a patient has only just been admitted with one (r or l leg) or two (r and l leg at same dt_stamp) motor block assessments at one dt_stamp, or if a patient only has one/two at same dt_stamp score during their entire ICU admission, calculation will not be possible and data will not be included on front tile average time between assessments metric.
+
+Once both scores have resumed to zero, motor block assessment is no longer required. This means that even if scores fall within the 12 hour assessment window, if both r and l leg scores are zero, do not calculate the measurement interval after scores of zero.
+
+Worked example:
+
+A patient has the following assessments calculated:
+
+1) 09:00 Motor block r leg = 2, Motor block l leg = 1
+2) 11:00 Motor block r leg =1, Motor block l leg = 1
+3) 13:00 Motor block r leg = 1, Motor block l leg = 0
+4) 15:00 Motor block r leg = 0, Motor block l leg = 0
+5) 19:00 Motor block r leg = 0, Motor block l leg = 0
+
+The interval between assessment 4 and 5 should not factor into the average time between measurements calculation because assessement four showed zero motor block. 
+
+This calculation on the front tile looks back from the current time to 24 hours in the past
+
+There will be two measurement interval calculations displayed on the front tile: DAY (08:00-19:59) and NIGHT (20:00-07:59)
+in line with other metrics we should provide some leeway (15 minutes) in charting documentation, therefore (adjusted time frame): DAY (08:00-19:59) and NIGHT (20:00-07:59). The leeway is to mitigate skewed mean interval, particularly in the DAY calculation (e.g. 08:01 motor block assessment, time interval calculated with a NIGHT motor block assessment at 02:00, would give a 04:01 measurement interval which would skew daytime data, the 15 minute leeway may need to be reviewed if insufficient
+
+The _dt of each measurement determines whether it is categorised as 'DAY' or 'NIGHT', but in order to complete the measurement interval calculation, a preceding measurement can be in the opposing category
+
+Worked example:
+
 (a) a motor block assessment documented at 08:10 would have to be linked with an earlier measurement during the night shift to calculate an interval and would be classified as - NIGHT (before 08:14)
+
 (b) an assessment documented at 8:30 would have to be linked with an earlier measurement during the day or night shift to calculate an interval and would be classified as - DAY (after 08:14)
+
 (c) an assessment documented at 20:10 would have to be linked with an earlier measurement during the day shift to calculate an interval and would be classified as - DAY (before 20:14)
 (d)an assessment documented 20:00 would have to be linked with an earlier measurement during the night or day shift to calculate an interval and would be classified as - NIGHT (after 20:14)
-once classified into DAY or NIGHT, determine numerator and denominator for each and calculate mean
-DAY Numerator = sum of the minutes and hours between all intervals recorded between (08:15-20:14) that fall into the current 24 hour rolling window
-DAY Denominator = number of all time interval measurements that fall into the current 24 hour rolling window
-NIGHT Numerator = sum of the minutes and hours between all intervals recorded between (20:15-08:14) that fall into the current 24 hour rolling window
-NIGHT Denominator = number of all time interval measurements that fall into the current 24 hour rolling window
+
+Once classified into DAY or NIGHT, determine numerator and denominator for each and calculate mean
+
+- DAY Numerator = sum of the minutes and hours between all intervals recorded between (08:15-20:14) that fall into the current 24 hour rolling window
+
+- DAY Denominator = number of all time interval measurements that fall into the current 24 hour rolling window
+
+- NIGHT Numerator = sum of the minutes and hours between all intervals recorded between (20:15-08:14) that fall into the current 24 hour rolling window
+
+- NIGHT Denominator = number of all time interval measurements that fall into the current 24 hour rolling window
 calculate respective DAY and NIGHT mean motor block assessment measurement interval and display as hh:mm on front tile
 
 


### PR DESCRIPTION
I have finally finished the SPC rules here and have also updated the rules to exclude scores from the measurement interval calculation once the motor block becomes zero. Niall can you review? I have not changed the 12 hour validity as I know we discussed but did not decide. 



