### PR TITLE
tool tip to CAM-ICU and targets hover over for SPC_charts_hoverbox.md

### DIFF
--- a/informus/content/SPC_charts_hoverbox.md
+++ b/informus/content/SPC_charts_hoverbox.md
@@ -61,11 +61,12 @@
 - Patients in range:
 - Eligible patients:
 
-## CAM-ICU Scores SPC Tool Tip (Hover Over Box) Content
+## CAM-ICU Scores SPC Tool Tip (Hover Over Box) Content (charts 1a, 1b, 1c)
 
 - Date:
 - Percentage:
 - Mean:
+- Eligible patients:
 
 ## CAM-ICU Scores Measurement Interval SPC Tool Tip (Hover Over Box) Content
 


### PR DESCRIPTION
Targets hover over box has not changed since we clearly defined in rules. 
CAM-ICU Delirium scores chart 1 a,b,c now include eligible patients as defined by n number in rules. 



